### PR TITLE
Fix insert many nil pointer issue

### DIFF
--- a/pkg/core/pmongo.go
+++ b/pkg/core/pmongo.go
@@ -288,7 +288,7 @@ func (s *DBConnection) UpdateFieldValue(ctx context.Context, query Q, collection
 }
 
 func (s *DBConnection) InsertMany(ctx context.Context, collectionName string, documents []interface{}) error {
-	_, err := Connection().Collection(collectionName).InsertMany(ctx, documents)
+	_, err := s.Collection(collectionName).InsertMany(ctx, documents)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

If the app uses the multiple MongoDB connection, the InsertMany function will generate the error "nil pointer". This PR will fix the issue of nil pointer.