### PR TITLE
Add find with projection

### DIFF
--- a/pkg/core/pmongo.go
+++ b/pkg/core/pmongo.go
@@ -309,3 +309,15 @@ func (s *DBConnection) FindLastestDocument(ctx context.Context, query Q, documen
 
 	return nil
 }
+
+// FindAllWithProjection returns all the documents based on given query and specific field(s) specified in projections
+func (s *DBConnection) FindAllWithProjection(ctx context.Context, query Q, p Q, document Document) (interface{}, error) {
+	opts := options.Find().SetProjection(p)
+	return s.FindAllWithOpts(ctx, query, document, opts)
+}
+
+// FindWithProjection returns the document based on given query and specific field(s) specified in projections
+func (s *DBConnection) FindWithProjection(ctx context.Context, query Q, p Q, document Document) error {
+	opts := options.FindOne().SetProjection(p)
+	return s.FindWithOpts(ctx, query, document, opts)
+}


### PR DESCRIPTION
## Description of the change

We are fetching the whole document even if we just need one value from the document. 
Add functions to use the projection to just fetch the value that we need

Example usage:
```
conn := data.SecondaryConnection()
	q := core.Q{
		"status":  "my_status",
	}

	p := core.Q{
		"my_value": 1,  //  this will be the only value that we will fetch
	}

	c := new(myCollection)
	results, err := conn.FindAllWithProjection(ctx, q, p, c)
```