### PR TITLE
Add function to update documents using query 

### DIFF
--- a/pkg/core/pmongo.go
+++ b/pkg/core/pmongo.go
@@ -389,3 +389,10 @@ func (s *DBConnection) FindFirstDocument(ctx context.Context, query Q, document 
 
 	return nil
 }
+
+// UpdateManyUsingQuery updates the field(s) based on the update query of the documents given by selector
+func (s *DBConnection) UpdateManyUsingQuery(ctx context.Context, selector Q, updateQuery Q, document Document) error {
+	coll := s.Collection(document.CollectionName())
+	_, err := coll.UpdateMany(ctx, selector, updateQuery)
+	return err
+}


### PR DESCRIPTION
## Description of the change

- Add function to update documents using query 


## Type of change
- [x] New Feature

## Changes
 - Added function `UpdateManyUsingQuery`
 - This function the fields based on the `updateQuery` for the documents given by `selector`
 - Example Usage:
 ```
 
	selector := core.Q{
		"myId": "634fc5d2dcf8bcb7cda9f6db",
	}

	updateQuery := core.Q{
		"$set": core.Q{
			"myKey": "myValuetoUpdate",
		},
	}

	core.Connection().UpdateManyUsingQuery(ctx, selector, updateQuery, myDocument)
 ```
 
 This is equivalent to following mongo query:
 ```
    
 db.myCollection.updateMany({myId:'634fc5d2dcf8bcb7cda9f6db'},
 {
  $set: {
      'myKey' : 'myValuetoUpdate'
  }
})
 ```
