### PR TITLE
feat: add ConditionalUpdateField for atomic conditional updates

### DIFF
--- a/pkg/core/pmongo.go
+++ b/pkg/core/pmongo.go
@@ -260,6 +260,16 @@ func (s *DBConnection) UpdateFieldValue(ctx context.Context, query Q, collection
 	return err
 }
 
+// ConditionalUpdateField atomically updates a single field only when the document matches the given
+// query. Returns true if the document was matched and updated, false if nothing matched.
+func (s *DBConnection) ConditionalUpdateField(ctx context.Context, query Q, collectionName, field string, value interface{}) (bool, error) {
+	result, err := s.Collection(collectionName).UpdateOne(ctx, query, bson.M{"$set": bson.M{field: value}})
+	if err != nil {
+		return false, err
+	}
+	return result.MatchedCount > 0, nil
+}
+
 // InsertMany inserts multiple documents into a collection.
 func (s *DBConnection) InsertMany(ctx context.Context, collectionName string, documents []interface{}) error {
 	_, err := s.Collection(collectionName).InsertMany(ctx, documents)


### PR DESCRIPTION
## Summary
- Adds `ConditionalUpdateField` on `*DBConnection`, parallel to `UpdateFieldValue`
- Uses MongoDB `UpdateOne` and returns `MatchedCount > 0` so callers can detect whether the document matched the filter (vs another goroutine already changed state)
- Needed by `capi` to implement an optimistic charge lock (`MSCharging` milestone state) that prevents concurrent agent + system charges from both reaching the payment gateway

## Test plan
- [ ] Verify `ConditionalUpdateField` returns `true` when document matches filter and is updated
- [ ] Verify `ConditionalUpdateField` returns `false` (no error) when no document matches the filter

🤖 Generated with [Claude Code](https://claude.ai/code)